### PR TITLE
Update the setup.py template to match xstatic standard

### DIFF
--- a/xstatic_release/__init__.py
+++ b/xstatic_release/__init__.py
@@ -36,21 +36,29 @@ universal = True
 '''
 
 PY_TEMPLATE = '''from setuptools import setup, find_packages
+from xstatic.pkg import {0.PACKAGE_NAME} as xs
 
 # The README.txt file should be written in reST so that PyPI can use
 # it to generate your project's PyPI page.
 long_description = open('README.txt').read()
 
 setup(
-    name='{0.PACKAGE_NAME}',
-    description="""{0.DESCRIPTION}""",
+    name=xs.PACKAGE_NAME,
+    version=xs.PACKAGE_VERSION,
+    description=xs.DESCRIPTION,
     long_description=long_description,
-    maintainer="{0.MAINTAINER}",
-    maintainer_email='{0.MAINTAINER_EMAIL}',
-    use_scm_version=True,
-    setup_requires=['setuptools_scm', 'wheel'],
+    classifiers=xs.CLASSIFIERS,
+    keywords=xs.KEYWORDS,
+    maintainer=xs.MAINTAINER,
+    maintainer_email=xs.MAINTAINER_EMAIL,
+    license=xs.LICENSE,
+    url=xs.HOMEPAGE,
+    platforms=xs.PLATFORMS,
     packages=find_packages(),
-    include_package_data=True
+    namespace_packages=['xstatic', 'xstatic.pkg', ],
+    include_package_data=True,
+    zip_safe=False,
+    install_requires=[],
 )
 '''
 


### PR DESCRIPTION
The content of setup.py for the xstatic packages is standard, and it has
been arrived at with a lot of pain and suffering.  All of its parts
serve a purpose in one corner case or other, and any changes should be
made very carefully and with testing.

In this case, particularly important are the "version" field, which is
needed for the installed packages to have proper egg-info metadata, and
the "namespace_packages" field, which makes sure the package is
installed in the proper namespace.

It's also important to not add arbitrary things to the "setup_requires"
field, as many build systems don't have unrestricted access to the
internet and can't just download the additional dependencies on demand.
